### PR TITLE
Fix QorumOnlineLogs for iOS

### DIFF
--- a/QorumLogs.swift
+++ b/QorumLogs.swift
@@ -198,7 +198,7 @@ public struct QorumOnlineLogs {
                 NSURLConnection(request: request, delegate: nil)?.start()
             }
         #elseif os(iOS)
-            NSURLSession.sharedSession().dataTaskWithRequest(request);
+            NSURLSession.sharedSession().dataTaskWithRequest(request).resume();
         #endif
 
         let printText = "OnlineLogs: \(extraInformation.description) - \(versionLevel) - \(classInformation) - \(text)"


### PR DESCRIPTION
Fix QorumOnlineLogs for iOS by adding missing .resume() call.

The dataTask for iOS was created and setup, but as is specified in the NSURLSession header:

"NSURLSessionTask objects are always created in a suspended state and must be sent the -resume message before they will execute."

Adding this causes the logs to properly be send to the Google Form.
