### PR TITLE
Add Carthage build folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,10 @@ xcuserdata/
 ####
 # UNKNOWN: recommended by others, but I can't discover what these files are
 #
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build


### PR DESCRIPTION
When using carthage and git-submodules, QorumLogs gets "dirty". This fixes that.
